### PR TITLE
devc

### DIFF
--- a/contracts/device_worker.py
+++ b/contracts/device_worker.py
@@ -135,7 +135,6 @@ class DeviceWorkerCore(DeviceWorker):
             self.progress.emit(int(100*counter/nr_of_files))
 
     def run(self):
-        # Catch the run in case of errors
         try:
             # Set the data
             self.set_data(self.dataset)
@@ -146,6 +145,7 @@ class DeviceWorkerCore(DeviceWorker):
             plot_type(title=title)
             self.finished.emit({"ok": True})
 
-        except Exception:
+        # Catchall is intentional
+        except Exception as e:
             import traceback
-            self.finished.emit({"ok": False, "traceback": traceback.format_exc()})
+            self.finished.emit({"ok": False,"message": f"{e}" ,"traceback": traceback.format_exc()})

--- a/contracts/device_worker.py
+++ b/contracts/device_worker.py
@@ -78,7 +78,7 @@ class DeviceWorkerCore(DeviceWorker):
             Subclasses provide plotting methods referenced by `plot_type` and may
             extend run behaviour if needed.
     """
-    finished = QtCore.pyqtSignal()
+    finished = QtCore.pyqtSignal(dict)
     progress = QtCore.pyqtSignal(int)
 
     def __init__(self, device, dataset, plot_type, options: PlotterOptions):
@@ -135,11 +135,17 @@ class DeviceWorkerCore(DeviceWorker):
             self.progress.emit(int(100*counter/nr_of_files))
 
     def run(self):
-        # Set the data
-        self.set_data(self.dataset)
+        # Catch the run in case of errors
+        try:
+            # Set the data
+            self.set_data(self.dataset)
 
-        # Grab the correct plot and execute it, including uuid in the title
-        title = f"{self.dataset.get_name()} (run {self.identifier})"
-        plot_type = getattr(self, self.plot_type)
-        plot_type(title=title)
-        self.finished.emit()
+            # Grab the correct plot and execute it, including uuid in the title
+            title = f"{self.dataset.get_name()} (run {self.identifier})"
+            plot_type = getattr(self, self.plot_type)
+            plot_type(title=title)
+            self.finished.emit({"ok": True})
+
+        except Exception:
+            import traceback
+            self.finished.emit({"ok": False, "traceback": traceback.format_exc()})

--- a/gui/plot_manager.py
+++ b/gui/plot_manager.py
@@ -91,8 +91,7 @@ def plot_manager(window, *args, **kwargs):
     window.device_worker.finished.connect(window.device_worker.deleteLater)
 
     # When the thread is actually finished, clean up and reset GUI
-    window.thread.finished.connect(window.thread.deleteLater)
-    window.thread.finished.connect(window.on_plot_thread_finished)
+    window.device_worker.finished.connect(window.on_plot_thread_finished)
 
     # Progress updates
     window.device_worker.progress.connect(window.report_progress)

--- a/gui/plot_manager.py
+++ b/gui/plot_manager.py
@@ -101,4 +101,4 @@ def plot_manager(window, *args, **kwargs):
     window.console_print(
         f"(run {window.device_worker.identifier}) producing {current_device_class}-{plot_function} plot for {window.get_dataset_name()} with options {options}")
 
-    window.plotBtn.setEnabled(False)
+    # window.plotBtn.setEnabled(False)

--- a/gui/plot_manager.py
+++ b/gui/plot_manager.py
@@ -100,5 +100,3 @@ def plot_manager(window, *args, **kwargs):
     window.thread.start()
     window.console_print(
         f"(run {window.device_worker.identifier}) producing {current_device_class}-{plot_function} plot for {window.get_dataset_name()} with options {options}")
-
-    # window.plotBtn.setEnabled(False)

--- a/gui/windows/MainWindow.py
+++ b/gui/windows/MainWindow.py
@@ -284,10 +284,10 @@ class UiMainWindow(QtWidgets.QMainWindow):
             with open(file_path, 'w') as file:
                 file.write(plaintext)
 
-    def console_print(self, fstring, level="normal"):
+    def console_print(self, message, level="normal"):
         # Print a message to the gui console
         now = datetime.datetime.now()
-        fstring_to_print = now.strftime(f"{constants.DATETIME_FORMAT}: ") + fstring
+        fstring_to_print = now.strftime(f"{constants.DATETIME_FORMAT}: ") + message
 
         c = ConsoleColours()
 

--- a/gui/windows/MainWindow.py
+++ b/gui/windows/MainWindow.py
@@ -256,7 +256,7 @@ class UiMainWindow(QtWidgets.QMainWindow):
 
         self.progressBar.setValue(progress)
 
-    def on_plot_thread_finished(self):
+    def on_plot_thread_finished(self, thread_data):
         # Reset UI elements
         self.progressBar.setValue(0)
 
@@ -267,6 +267,12 @@ class UiMainWindow(QtWidgets.QMainWindow):
         # Drop strong references so GC can do its thing
         self.device_worker = None
         self.thread = None
+
+        if thread_data['ok']:
+            self.console_print(f"(run {self.device_worker.identifier}) finished succesfully")
+        else:
+            self.console_print(message=thread_data["traceback"], level="alert")
+            print(thread_data["traceback"])
 
     def save_to_file(self, plaintext: str):
         file_dialog = QtWidgets.QFileDialog.getSaveFileName(self, "Save File", "", "Text Files (*.txt);;All Files (*)")

--- a/gui/windows/MainWindow.py
+++ b/gui/windows/MainWindow.py
@@ -262,9 +262,12 @@ class UiMainWindow(QtWidgets.QMainWindow):
 
         # Free button and log to console
         self.plotBtn.setEnabled(True)
-        self.console_print(f"(run {self.device_worker.identifier}) finished")
 
-        # Drop strong references so GC can do its thing
+        # Cleanup the worker and the thread
+        self.thread.quit()
+        self.thread.wait()
+        self.thread.deleteLater()
+
         self.device_worker = None
         self.thread = None
 

--- a/gui/windows/MainWindow.py
+++ b/gui/windows/MainWindow.py
@@ -274,7 +274,7 @@ class UiMainWindow(QtWidgets.QMainWindow):
         if thread_data['ok']:
             self.console_print(f"(run {self.device_worker.identifier}) finished succesfully")
         else:
-            self.console_print(message=thread_data["traceback"], level="alert")
+            self.console_print(message=thread_data["message"], level="alert")
             print(thread_data["traceback"])
 
     def save_to_file(self, plaintext: str):


### PR DESCRIPTION
Catch thread errors to prevent UI crashing. Error is sent to UI console, full traceback is sent to the terminal through print()